### PR TITLE
Add image-mirror examples

### DIFF
--- a/image-mirror/README.md
+++ b/image-mirror/README.md
@@ -1,0 +1,20 @@
+# Image Mirror Examples
+
+These are examples of custom scripts for mirroring images from `cgr.dev` to
+another registry.
+
+## Scripts
+
+### Basic
+
+See: [`./basic`](./basic) 
+
+This simple example iterates through the latest images in a `cgr.dev` repository
+and mirrors them to a destination registry.
+
+### Advanced
+
+See: [`./advanced`](./advanced)
+
+This a more complex example that filters out image updates unless they resolve
+vulnerabilities.

--- a/image-mirror/advanced/README.md
+++ b/image-mirror/advanced/README.md
@@ -1,0 +1,49 @@
+# Image Mirror Example: Chainctl Image Diff
+
+This is an example of a custom script that mirrors images from a
+repository in `cgr.dev` to another registry, using `chainctl image diff` to
+select updates that meaningfully reduce CVEs.
+
+It avoids copying an image unless:
+
+1. It introduces a new tag that doesn't already exist in the destination
+   repository.
+2. It resolves a vulnerability that is present in an existing tag.
+3. The image has already been partially copied to some of the tags in the
+   destination. Copying in this scenario ensures consistency across tags in the
+   destination.
+
+This is intended to minimize the volume of changes, hopefully reducing the
+toil that may be involved in reviewing and staying up to date with updates.
+
+To make the script more efficient, it only copies images that were updated in
+the last three days. Supported tags of Chainguard images are updated on a daily
+basis.
+
+## Requirements
+
+- [`chainctl`](https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/)
+- [`cosign`](https://github.com/sigstore/cosign)
+- [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane)
+- [`grype`](https://github.com/anchore/grype)
+- [`jq`](https://github.com/jqlang/jq)
+
+## Usage
+
+There are two arguments:
+
+1. The source repository in `cgr.dev`.
+2. The destination repository.
+
+```sh
+./image-mirror.sh cgr.dev/org.name/python registry.org.name.internal/cgr/python
+```
+
+Before running the script, ensure you have logged into Chainguard and the
+destination registry.
+
+```
+docker login -u username -p password example.registry
+chainctl auth login
+chainctl auth configure-docker
+```

--- a/image-mirror/advanced/image-mirror.sh
+++ b/image-mirror/advanced/image-mirror.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Retrieve positional arguments
+src_repo="${1:?Must provide cgr.dev repository as the first argument.}"
+dst_repo="${2:?Must provide destination repository as the second argument.}"
+
+# Ensure the cgr.dev repo looks how its supposed to
+if [[ ! ${src_repo} =~ ^cgr.dev/[^/]+/[^/:@]+$ ]]; then
+  echo "ERROR: first argument '${src_repo}' must look like: cgr.dev/{org_name}/{repo}" >&2
+  exit 1
+fi
+
+# Extract components from cgr.dev repo
+org_name="$(r=${src_repo#*/}; echo ${r%/*})"
+repo_name="${src_repo##*/}"
+
+# Check we have the required tools installed to run the script
+cmds="
+  chainctl
+  cosign
+  crane
+  grype
+  jq
+"
+missing_cmds=""
+for cmd in ${cmds}; do
+  if ! command -v "${cmd}" &> /dev/null; then
+    missing_cmds+="${cmd} "
+  fi
+done
+if [[ -n "${missing_cmds}" ]]; then
+  echo "Missing required commands: ${missing_cmds}" >&2
+  exit 1
+fi
+
+# Create a temp dir where we can write files
+tmpdir=$(mktemp -d)
+
+# Clean up the temp dir when the script exits
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+function main() {
+  # List every tag that has been updated in the last 72h, aggregate by digest into
+  # a structure like:
+  #
+  # [
+  #   {
+  #     "digest": "",
+  #     "tags": [
+  #       ""
+  #     ]
+  #   }
+  # ]
+  image_list=$(
+    chainctl image list \
+      --parent="${org_name}" \
+      --repo="${repo_name}" \
+      --updated-within=72h \
+      -o json \
+      | jq -c '.[].tags | group_by(.digest) | .[] | { digest: .[0].digest, tags: map(.name) }'
+  )
+
+  # Iterate over each image in the list.
+  while read -r img; do
+    digest=$(jq -r .digest <<<"${img}")
+
+    # Check whether we want to copy this image
+    echo "Checking ${digest} $(jq -c .tags <<<"${img}")..." >&2
+    if ! should_copy "${img}"; then
+      echo "Skipped ${digest}" >&2
+      continue
+    fi
+
+    src="${src_repo}@${digest}"
+
+    # Verify the signature before we copy the image
+    echo "Verifying signature for ${digest}..."
+    cosign verify \
+      --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+      --certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+      "${src}" &>/dev/null
+
+    # Perform the copy
+    echo "Copying ${digest} to ${dst_repo}..." >&2
+    while read -r tag; do
+      dst="${dst_repo}:${tag}"
+
+      echo "Copying ${src} to ${dst}..." >&2
+      crane copy "${src}" "${dst}"
+    done < <(jq -rc '.tags[]' <<<"${img}")
+  done <<<"${image_list}"
+}
+
+function should_copy() {
+  local img="${1}"
+  local digest=$(jq -r .digest <<<"${img}")
+  local dst_tags='[]'
+
+  # Figure out the digests for the existing tags in the repository
+  while read -r tag; do
+    dst_digest=$(crane digest "${dst_repo}:${tag}" 2>/dev/null || true)
+
+    # If the the destination tag doesn't exist at all, then we should copy the
+    # image and we can stop here.
+    if [[ -z "${dst_digest}" ]]; then
+      echo "${dst_repo}:${tag} doesn't exist" >&2
+      return 0
+    fi
+
+    dst_tags=$(jq -rc --arg digest "${dst_digest}" --arg tag "${tag}" '. += [{"digest": $digest, "tag": $tag}]' <<<"${dst_tags}")
+  done < <(jq -rc '.tags[]' <<<"${img}")
+
+  # If some of the tags in the destination match the new digest, but others
+  # don't, then we want to copy to make sure the destination stays consistent
+  # between tags.
+  local match_count=0
+  local total_count=0
+  while read -r dst_tag; do
+    ((total_count++))
+    dst_digest=$(jq -r '.digest' <<<"${dst_tag}")
+    if [[ "${dst_digest}" == "${digest}" ]]; then
+      ((match_count++))
+    fi
+  done < <(jq -rc '.[]' <<<"${dst_tags}")
+  if [[ ${match_count} -gt 0 && ${match_count} -lt ${total_count} ]]; then
+    echo "The destination is out of sync for ${digest}" >&2
+    return 0
+  fi
+
+  # Finally, where the destination tag is a different image, use chainctl image
+  # diff to figure out if the update would resolve any vulnerabilities.
+  while read -r tag; do
+    dst_digest=$(jq -r '.digest' <<<"${tag}")
+    dst_tag=$(jq -r '.tag' <<<"${tag}")
+
+    # Naturally there's no use in diffing two identical images.
+    if [[ "${dst_digest}" == "${digest}" ]]; then
+      continue
+    fi
+
+    # Avoid diffing images we've already diffed by saving results to a file
+    # derived from the digests
+    diff_file="${tmpdir}/${dst_digest}_${digest}.json"
+
+    # Run chainctl image diff
+    echo "Diffing ${dst_repo}:${dst_tag} and ${src_repo}@${digest}..." >&2
+    if [[ ! -f "${diff_file}" ]]; then
+      chainctl image diff "${src_repo}@${dst_digest}" "${src_repo}@${digest}" -o json > "${diff_file}" 2>/dev/null
+    fi
+
+    # We don't want to copy if the update doesn't resolve any vulnerabilities
+    if [[ -z $(jq -r '.vulnerabilities.removed // [] | .[].id' "${diff_file}") ]]; then
+      echo "No vulnerabilities will be removed by copying ${digest} to ${dst_repo}:${dst_tag}" >&2
+      continue
+    fi
+
+    echo "${digest} resolves vulnerabilties in ${dst_repo}:${dst_tag}" >&2
+    return 0
+  done < <(jq -rc '.[]' <<<"${dst_tags}")
+
+  return 1
+}
+
+main

--- a/image-mirror/basic/README.md
+++ b/image-mirror/basic/README.md
@@ -1,0 +1,36 @@
+# Image Mirror Example: Basic 
+
+This is a simple example of a custom script that mirrors images from a
+repository in `cgr.dev` to another registry.
+
+To make the script more efficient, it only copies images that were updated in
+the last three days. Supported tags of Chainguard images are updated on a daily
+basis.
+
+## Requirements
+
+- [`chainctl`](https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/)
+- [`cosign`](https://github.com/sigstore/cosign)
+- [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane)
+- [`jq`](https://github.com/jqlang/jq)
+
+## Usage
+
+There are two arguments:
+
+1. The source repository in `cgr.dev`.
+2. The destination repository.
+
+```sh
+./image-mirror.sh cgr.dev/org.name/python example.registry/chainguard/python
+```
+
+Before running the script, ensure you have logged into Chainguard and the
+destination registry.
+
+```
+docker login -u username -p password example.registry
+chainctl auth login
+chainctl auth configure-docker
+```
+

--- a/image-mirror/basic/image-mirror.sh
+++ b/image-mirror/basic/image-mirror.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Retrieve positional arguments
+src_repo="${1:?Must provide cgr.dev repository as the first argument.}"
+dst_repo="${2:?Must provide destination repository as the second argument.}"
+
+# Ensure the cgr.dev repo looks how its supposed to
+if [[ ! ${src_repo} =~ ^cgr.dev/[^/]+/[^/:@]+$ ]]; then
+  echo "ERROR: first argument '${src_repo}' must look like: cgr.dev/{org_name}/{repo}" >&2
+  exit 1
+fi
+
+# Extract components from cgr.dev repo
+org_name="$(r=${src_repo#*/}; echo ${r%/*})"
+repo_name="${src_repo##*/}"
+
+# Check we have the required tools installed to run the script
+cmds="
+  chainctl
+  cosign
+  crane
+  jq
+"
+missing_cmds=""
+for cmd in ${cmds}; do
+  if ! command -v "${cmd}" &> /dev/null; then
+    missing_cmds+="${cmd} "
+  fi
+done
+if [[ -n "${missing_cmds}" ]]; then
+  echo "Missing required commands: ${missing_cmds}" >&2
+  exit 1
+fi
+
+# List every tag that has been updated in the last 72h. 
+#
+# This produces a list of images in the form <repo>:<tag>@<digest>.
+image_list=$(
+  chainctl image list \
+    --parent="${org_name}" \
+    --repo="${repo_name}" \
+    --updated-within=72h \
+    -o json \
+    | jq -r --arg src_repo "${src_repo}" '.[].tags[] | $src_repo + ":" + .name + "@" + .digest'
+)
+
+# Iterate over each image
+while read -r src; do
+    tag=$(t=${src#*:}; echo ${t%@*})
+    dst="${dst_repo}:${tag}"
+
+    # Verify the signature before we copy it
+    echo "Verifying signature for ${src}..."
+    cosign verify \
+      --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+      --certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+      "${src}" &>/dev/null
+
+    # You could use `cosign copy` here if you wanted to also copy the
+    # signatures/attestations
+    echo "Copying ${src} to ${dst}..." >&2
+    crane copy "${src}" "${dst}"
+done <<<"${image_list}"


### PR DESCRIPTION
These are examples of scripts that copy images from a repository in `cgr.dev` to another registry.