### PR TITLE
Replace bind mount method with base chroot in trainer development material

### DIFF
--- a/train-the-trainer/developer-track/python-example-2/Dockerfile
+++ b/train-the-trainer/developer-track/python-example-2/Dockerfile
@@ -8,12 +8,10 @@ USER root
 # Comment out or remove if specified system-level packages do not need to be present during the build stage
 RUN apk add --no-cache ${APK_LIST}
 
-# Build a script used to install packages during the distroless stage
-# The find commands allow us to avoid hardcoding the version number of libapk.so
-RUN echo "cp /lib/libapk.so $(find /lib -name 'libapk.so*')" > /add_apks.sh
-RUN echo "apk add --no-cache ${APK_LIST}" >> /add_apks.sh
-RUN echo "rm $(find /lib -name 'libapk.so*')" >> /add_apks.sh
-RUN cp $(find /lib -name 'libapk.so*') /lib/libapk.so
+# Install the packages into a root derived from the distroless image.
+COPY --from=cgr.dev/chainguard/python:latest / /base-chroot
+RUN apk add --no-commit-hooks --no-cache --root /base-chroot ${APK_LIST}
+
 USER 65532
 
 # Install desired Python packages
@@ -27,24 +25,13 @@ RUN pip install --upgrade pip setuptools wheel && \
 
 FROM cgr.dev/chainguard/python:latest
 
+# Replace the filesystem with the one containing the additional packages.
+COPY --from=dev /base-chroot /
+
 WORKDIR /app
 COPY --from=dev /app/venv /app/venv
 COPY run.py run.py
-USER root
 
-# Mount resources needed to install apks and run the install script
-RUN --mount=type=bind,from=dev,target=/sbin/apk,source=/sbin/apk \
-   --mount=type=bind,from=dev,target=/bin/busybox,source=/bin/busybox \
-   --mount=type=bind,from=dev,target=/bin/sh,source=/bin/sh \
-   --mount=type=bind,from=dev,target=/bin/cp,source=/bin/cp \
-   --mount=type=bind,from=dev,target=/bin/rm,source=/bin/rm \
-   --mount=type=bind,from=dev,target=/etc/apk/keys,source=/etc/apk/keys,rw \
-   --mount=type=bind,from=dev,target=/etc/apk/repositories,source=/etc/apk/repositories,rw \
-   --mount=type=bind,from=dev,target=/etc/apk/protected_paths.d,source=/etc/apk/protected_paths.d,rw \
-   --mount=type=bind,from=dev,target=/lib/libapk.so,source=/lib/libapk.so,rw \
-   --mount=type=bind,from=dev,target=/add_apks.sh,source=/add_apks.sh,rw \
-   /bin/sh /add_apks.sh
-
-USER 65532
 ENV PATH="/app/venv/bin:$PATH"
+
 ENTRYPOINT ["python", "run.py"]

--- a/train-the-trainer/developer-track/python-example-3/Dockerfile
+++ b/train-the-trainer/developer-track/python-example-3/Dockerfile
@@ -13,12 +13,10 @@ ENV PATH="/app/venv/bin":$PATH
 # Comment out or remove if specified system-level packages do not need to be present during the build stage
 RUN apk add --no-cache ${APK_LIST}
 
-# Build a script used to install packages during the distroless stage
-# The find commands allow us to avoid hardcoding the version number of libapk.so
-RUN echo "cp /lib/libapk.so $(find /lib -name 'libapk.so*')" > /add_apks.sh
-RUN echo "apk add --no-cache ${APK_LIST}" >> /add_apks.sh
-RUN echo "rm $(find /lib -name 'libapk.so*')" >> /add_apks.sh
-RUN cp $(find /lib -name 'libapk.so*') /lib/libapk.so
+# Install the packages into a root derived from the distroless image.
+COPY --from=cgr.dev/chainguard/python:latest / /base-chroot
+RUN apk add --no-commit-hooks --no-cache --root /base-chroot ${APK_LIST}
+
 USER 0
 
 # Install desired Python packages
@@ -32,27 +30,15 @@ RUN pip install --upgrade pip setuptools wheel && \
 
 FROM cgr.dev/chainguard/python:latest
 
+# Replace the filesystem with the one containing the additional packages.
+COPY --from=dev /base-chroot /
+
 WORKDIR /app
 
 COPY --from=dev /app/__pycache__ /app/__pycache__
-COPY --from=dev add_apks.sh add_apks.sh
 COPY --from=dev /app/venv /app/venv
 COPY main.py main.py
-USER root
 
-# Mount resources needed to install apks and run the install script
-RUN --mount=type=bind,from=dev,target=/sbin/apk,source=/sbin/apk \
-   --mount=type=bind,from=dev,target=/bin/busybox,source=/bin/busybox \
-   --mount=type=bind,from=dev,target=/bin/sh,source=/bin/sh \
-   --mount=type=bind,from=dev,target=/bin/cp,source=/bin/cp \
-   --mount=type=bind,from=dev,target=/bin/rm,source=/bin/rm \
-   --mount=type=bind,from=dev,target=/etc/apk/keys,source=/etc/apk/keys,rw \
-   --mount=type=bind,from=dev,target=/etc/apk/repositories,source=/etc/apk/repositories,rw \
-   --mount=type=bind,from=dev,target=/etc/apk/protected_paths.d,source=/etc/apk/protected_paths.d,rw \
-   --mount=type=bind,from=dev,target=/lib/libapk.so,source=/lib/libapk.so,rw \
-   --mount=type=bind,from=dev,target=/add_apks.sh,source=/add_apks.sh,rw \
-   /bin/sh /add_apks.sh
-
-USER 0
 ENV PATH="/app/venv/bin:$PATH"
-ENTRYPOINT ["python", "__pycache__/main.cpython-312.pyc"]
+
+ENTRYPOINT ["python", "__pycache__/main.cpython-313.pyc"]


### PR DESCRIPTION
This is our recommended method for installing apk packages into distroless images.