### PR TITLE
Fix CVE GHSA-5rjg-fvgr-3xxf  from pip requirements

### DIFF
--- a/python/linky/requirements.txt
+++ b/python/linky/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==70.0.0
+setuptools==78.1.1
 climage==0.2.0

--- a/python/not-linky/requirements.txt
+++ b/python/not-linky/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==70.0.0
+setuptools==78.1.1
 climage==0.2.0


### PR DESCRIPTION
Resolves
```
NAME        INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS %  RISK
setuptools  70.0.0     78.1.1    python  GHSA-5rjg-fvgr-3xxf  High      31.77   < 0.1
```