### PR TITLE
Python migration deck

### DIFF
--- a/python/linky/Dockerfile
+++ b/python/linky/Dockerfile
@@ -13,7 +13,6 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-ARG IMAGE_REGISTRY="cgr.dev/chainguard"
 FROM ${IMAGE_REGISTRY}/python:latest
 
 WORKDIR /linky

--- a/python/not-linky/Dockerfile
+++ b/python/not-linky/Dockerfile
@@ -1,28 +1,17 @@
 ARG IMAGE_REGISTRY="docker.io/library"
-FROM ${IMAGE_REGISTRY}/python:latest AS builder
+FROM ${IMAGE_REGISTRY}/python:latest
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-ENV PATH="/not-linky/venv/bin:$PATH"
+ENV PATH="/venv/bin:$PATH"
 
 WORKDIR /not-linky
 
-RUN python -m venv /not-linky/venv
 COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-ARG IMAGE_REGISTRY="docker.io/library"
-FROM ${IMAGE_REGISTRY}/python:latest
-
-WORKDIR /not-linky
-
-ENV PYTHONUNBUFFERED=1
-ENV PATH="/venv/bin:$PATH"
-
 COPY not-linky.py not-linky.png ./
-COPY --from=builder /not-linky/venv /venv
 
 ENTRYPOINT [ "python", "/not-linky/not-linky.py" ]
-


### PR DESCRIPTION
Updated this example to include steps showing the differences between multi-stage and single-stage builds with Chainguard images.