### PR TITLE
custom-assembly: iac: add support for --save-as

### DIFF
--- a/custom-assembly/iac/demo.sh
+++ b/custom-assembly/iac/demo.sh
@@ -43,12 +43,6 @@ pe "cat images/custom-iac-demo-python.yaml"
 pe "./presubmit.sh ${ORGANIZATION}"
 pe "git checkout HEAD images/custom-iac-demo-python.yaml"
 
-banner "We'll also get an error if the repo doesn't exist."
-pe "cp images/custom-iac-demo-python.yaml images/custom-iac-demo-foobar.yaml"
-pe "ls -l images/"
-pe "./presubmit.sh ${ORGANIZATION}"
-pe "rm images/custom-iac-demo-foobar.yaml"
-
 banner "Check that the presubmit checks are still passing."
 pe "./presubmit.sh ${ORGANIZATION}"
 

--- a/custom-assembly/iac/images/custom-iac-demo-node.yaml
+++ b/custom-assembly/iac/images/custom-iac-demo-node.yaml
@@ -1,2 +1,4 @@
-contents:
-  packages: []
+source: "node" 
+custom_overlay:
+  contents:
+    packages: []

--- a/custom-assembly/iac/images/custom-iac-demo-python.yaml
+++ b/custom-assembly/iac/images/custom-iac-demo-python.yaml
@@ -1,4 +1,6 @@
-contents:
-  packages:
-    - mariadb-connector-c
-    - mariadb-connector-c-dev
+source: "python"
+custom_overlay:
+  contents:
+    packages:
+      - mariadb-connector-c
+      - mariadb-connector-c-dev

--- a/custom-assembly/iac/postsubmit.sh
+++ b/custom-assembly/iac/postsubmit.sh
@@ -13,9 +13,32 @@ while read -r f; do
   repo="${repo%.yaml}"
   repo="${repo%.yml}"
 
-  echo "${f}: applying..." 2>/dev/null  
-  chainctl image repo build apply --yes \
-    --parent="${org_name}" \
-    --repo="${repo}" \
-    -f "${f}"
+  # Extract the custom overlay from the file
+  custom_overlay="${tmp_dir}/${repo}.yaml"
+  yq '.custom_overlay' "${f}" > "${tmp_dir}/${repo}.yaml" 
+
+  echo "${f}: checking if repo exists..." >&2
+  if [[ -z $(chainctl image repo list --parent="${org_name}" --repo="${repo}" -o id) ]]; then
+    # If the repo doesn't exist, then we can use the --save-as functionality to
+    # create it from the 'source'
+    echo "${f}: creating repo..." >&2
+    source=$(yq '.source' "${f}")
+
+    editor_sh="${tmp_dir}/${repo}-editor.sh"
+    echo -e '#!/bin/bash\ncat '"${custom_overlay}"' > "$1"' > "${editor_sh}"
+    chmod +x "${editor_sh}" 
+
+    EDITOR="${editor_sh}" chainctl image repo build edit \
+      --parent="${org_name}" \
+      --repo="${source}" \
+      --save-as="${repo}" \
+      <<<y
+  else
+    # If it does exist then apply the custom overlay to it
+    echo "${f}: applying..." >&2
+    chainctl image repo build apply --yes \
+      --parent="${org_name}" \
+      --repo="${repo}" \
+      -f "${custom_overlay}"
+  fi
 done < <(find images -type f -name '*.yaml' -o -name '*.yml')


### PR DESCRIPTION
This allows you to instantiate a new custom assembly image by creating `images/{repo_name}.yaml`.